### PR TITLE
keep Docker cgroup net_cls limit and revert process grep method (#53)

### DIFF
--- a/pkg/socker/socker.go
+++ b/pkg/socker/socker.go
@@ -462,7 +462,7 @@ func (s *Socker) setCgroupLimit(pids []string, cgroupID string) error {
 	for _, pid := range pids {
 		// frees process from the docker cgroups.
 		output, err := exec.Command(cmdCgclassify, "-g",
-			"blkio,net_cls,devices,cpu,cpuset,memory:/", pid).CombinedOutput()
+			"cpu,cpuset,memory,devices:/", pid).CombinedOutput()
 		log.Debugf("frees container cgroups limit")
 		if err != nil {
 			log.Errorf("frees container cgroups limit failed: %v:%s", err, output)
@@ -484,8 +484,7 @@ func (s *Socker) setCgroupLimit(pids []string, cgroupID string) error {
 
 // QueryChildPIDs lookups child process ids of specified parent process.
 func QueryChildPIDs(parentID string) ([]string, error) {
-	grepCmd := fmt.Sprintf(`pstree -p %s | grep -o '([0-9]\+)' | grep -o '[0-9]\+'`, parentID)
-	out, err := exec.Command("bash", "-c", grepCmd).CombinedOutput()
+	out, err := exec.Command(cmdPgrep, "-P", parentID).CombinedOutput()
 	if err != nil {
 		// if no processes were matched pgrep exit with 1
 		if strings.Contains(err.Error(), "exit status 1") {


### PR DESCRIPTION
* fix: keep Docker cgroup net_cls limit

* fix: no need to grep all grandchild processes